### PR TITLE
 use createPopulatedBlock for the tests

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -77,8 +77,8 @@ func createEmptyBlock(t *testing.T, dir string, meta *BlockMeta) *Block {
 	return b
 }
 
-// createPopulatedBlock creates a block with nSeries series, and nSamples samples.
-func createPopulatedBlock(tb testing.TB, dir string, nSeries, nSamples int) *Block {
+// createPopulatedBlock creates a block with nSeries series, filled with samples between blockMint and blockMaxt.
+func createPopulatedBlock(tb testing.TB, dir string, nSeries int, blockMint, blockMaxt int64) *Block {
 	head, err := NewHead(nil, nil, nil, 2*60*60*1000)
 	testutil.Ok(tb, err)
 	defer head.Close()
@@ -87,17 +87,16 @@ func createPopulatedBlock(tb testing.TB, dir string, nSeries, nSamples int) *Blo
 	testutil.Ok(tb, err)
 	refs := make([]uint64, nSeries)
 
-	for n := 0; n < nSamples; n++ {
+	for ; blockMint <= blockMaxt; blockMint++ {
 		app := head.Appender()
-		ts := n * 1000
 		for i, lbl := range lbls {
 			if refs[i] != 0 {
-				err := app.AddFast(refs[i], int64(ts), rand.Float64())
+				err := app.AddFast(refs[i], int64(blockMint), rand.Float64())
 				if err == nil {
 					continue
 				}
 			}
-			ref, err := app.Add(lbl, int64(ts), rand.Float64())
+			ref, err := app.Add(lbl, blockMint, rand.Float64())
 			testutil.Ok(tb, err)
 			refs[i] = ref
 		}

--- a/querier_test.go
+++ b/querier_test.go
@@ -1301,12 +1301,12 @@ func BenchmarkMergedSeriesSet(b *testing.B) {
 
 func BenchmarkPersistedQueries(b *testing.B) {
 	for _, nSeries := range []int{10, 100} {
-		for _, nSamples := range []int{1000, 10000, 100000} {
+		for _, nSamples := range []int64{1000, 10000, 100000} {
 			b.Run(fmt.Sprintf("series=%d,samplesPerSeries=%d", nSeries, nSamples), func(b *testing.B) {
 				dir, err := ioutil.TempDir("", "bench_persisted")
 				testutil.Ok(b, err)
 				defer os.RemoveAll(dir)
-				block := createPopulatedBlock(b, dir, nSeries, nSamples)
+				block := createPopulatedBlock(b, dir, nSeries, 1, nSamples)
 				defer block.Close()
 
 				q, err := NewBlockQuerier(block, block.Meta().MinTime, block.Meta().MaxTime)


### PR DESCRIPTION
unfortunately I couldn't find an easy way to implement my idea so although it is counter intuitive I don't see any better way to write the block size at the time it is created instead of when it is being open at reload.

Here is a PR with few small changes and one thing I noticed is that it would be good to check that the reported block size matches the size when checked with os.Stat so I added a `// TODO` note if you don't mind adding this as well.

https://github.com/mknapphrt/tsdb/compare/size_based_retention...krasi-georgiev:pull/343-orig?expand=1#diff-65348100fd3ccd8cb8fb4f6bad6bc2d9R963

Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>